### PR TITLE
Solving paths issues in tests on Windows

### DIFF
--- a/core/src/test/java/fr/inria/atlanmod/neoemf/util/NeoURITest.java
+++ b/core/src/test/java/fr/inria/atlanmod/neoemf/util/NeoURITest.java
@@ -1,6 +1,7 @@
 package fr.inria.atlanmod.neoemf.util;
 
 import java.io.File;
+import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
 import org.junit.After;
@@ -13,6 +14,8 @@ import fr.inria.atlanmod.neoemf.datastore.PersistenceBackendFactoryRegistry;
 
 public class NeoURITest {
 
+	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoURITestFile";
+
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = Mockito.mock(AbstractPersistenceBackendFactory.class);
 	private File testFile = null;
 	
@@ -20,7 +23,7 @@ public class NeoURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put("mock", persistenceBackendFactory);
-		testFile = new File("src/test/resources/neoURITestFile");
+		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
 	}
 	
 	@After

--- a/graph/blueprints-neo4j/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/neo4j/resources/BlueprintsNeo4jResourceSaveTest.java
+++ b/graph/blueprints-neo4j/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/neo4j/resources/BlueprintsNeo4jResourceSaveTest.java
@@ -12,6 +12,7 @@ package fr.inria.atlanmod.neoemf.graph.blueprints.neo4j.resources;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -22,7 +23,9 @@ import fr.inria.atlanmod.neoemf.datastore.InvalidDataStoreException;
 import fr.inria.atlanmod.neoemf.graph.blueprints.resources.BlueprintsResourceSaveTest;
 
 public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest {
-    
+
+    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphNeo4jResourceSaveOptionTestFile";
+
     /**
      * Used to verify a property added by Blueprints during the graph creation
      */
@@ -31,11 +34,11 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
      * Number of properties for an empty Neo4j instance (with no option provided)
      */
     private static final int defaultPropertyCount = 3;
-    
+
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
-        this.testFilePath = "src/test/resources/graphNeo4jResourceSaveOptionTestFile";
+        this.testFilePath = TEST_FILE_PATH;
         super.setUp();
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE, BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_TYPE_NEO4J);
     }
@@ -46,7 +49,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
         options.clear();
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE, BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_TYPE_NEO4J);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE);
@@ -65,7 +68,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNoneCacheTypeOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE, BlueprintsNeo4jResourceOptions.CACHE_TYPE.NONE);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE);
@@ -85,7 +88,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceWeakCacheTypeOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE, BlueprintsNeo4jResourceOptions.CACHE_TYPE.WEAK);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE);
@@ -105,7 +108,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceSoftCacheTypeOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE,BlueprintsNeo4jResourceOptions.CACHE_TYPE.SOFT);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE);
@@ -125,7 +128,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceStrongCacheTypeOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE, BlueprintsNeo4jResourceOptions.CACHE_TYPE.STRONG);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_CACHE_TYPE);
@@ -145,7 +148,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceTrueUseMemoryMappedBuffersOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS, BlueprintsNeo4jResourceOptions.USE_MEMORY_MAPPED_BUFFER.TRUE);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS);
@@ -165,7 +168,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceTrueBooleanUseMemoryMappedBuffersOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS, true);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS);
@@ -185,7 +188,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceFalseUseMemoryMappedBuffersOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS, BlueprintsNeo4jResourceOptions.USE_MEMORY_MAPPED_BUFFER.FALSE);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS);
@@ -205,7 +208,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceFalseBooleanUseMemoryMappedBuffersOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS, false);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_USE_MEMORY_MAPPED_BUFFERS);
@@ -226,7 +229,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourcePositiveStringsMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_STRINGS_MAPPED_MEMORY, "64M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_STRINGS_MAPPED_MEMORY);
@@ -262,7 +265,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNullStringsMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_STRINGS_MAPPED_MEMORY, "0M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_STRINGS_MAPPED_MEMORY);
@@ -283,7 +286,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourcePositiveArraysMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_ARRAYS_MAPPED_MEMORY,"64M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_ARRAYS_MAPPED_MEMORY);
@@ -319,7 +322,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNullArraysMappedMemoryOption () throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_ARRAYS_MAPPED_MEMORY,"0M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_ARRAYS_MAPPED_MEMORY);
@@ -340,7 +343,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourcePositiveNodesMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_NODES_MAPPED_MEMORY,"64M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_NODES_MAPPED_MEMORY);
@@ -376,7 +379,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNullNodesMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_NODES_MAPPED_MEMORY,"0M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_NODES_MAPPED_MEMORY);
@@ -397,7 +400,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourcePositivePropertiesMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_PROPERTIES_MAPPED_MEMORY,"64M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_PROPERTIES_MAPPED_MEMORY);
@@ -433,7 +436,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNullPropertiesMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_PROPERTIES_MAPPED_MEMORY,"0M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_PROPERTIES_MAPPED_MEMORY);
@@ -454,7 +457,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourcePositiveRelationshipsMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_RELATIONSHIPS_MAPPED_MEMORY,"64M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_RELATIONSHIPS_MAPPED_MEMORY);
@@ -490,7 +493,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     public void testSaveGraphNeo4jResourceNullRelationshipsMappedMemoryOption() throws IOException, ConfigurationException {
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_RELATIONSHIPS_MAPPED_MEMORY,"0M");
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists();
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_NEO4J_RELATIONSHIPS_MAPPED_MEMORY);

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/datastore/BlueprintsPersistenceBackendFactoryTest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/datastore/BlueprintsPersistenceBackendFactoryTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.emf.ecore.InternalEObject.EStore;
@@ -39,6 +40,8 @@ import fr.inria.atlanmod.neoemf.graph.blueprints.util.NeoBlueprintsURI;
 import fr.inria.atlanmod.neoemf.resources.PersistentResourceOptions;
 
 public class BlueprintsPersistenceBackendFactoryTest {
+
+    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphPersistenceBackendFactoryTestFile";
     
     protected AbstractPersistenceBackendFactory persistenceBackendFactory = null;
     protected File testFile = null;
@@ -51,7 +54,7 @@ public class BlueprintsPersistenceBackendFactoryTest {
     public void setUp() {
         persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-        testFile = new File("src/test/resources/graphPersistenceBackendFactoryTestFile");
+        testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
         options.put(PersistentResourceOptions.STORE_OPTIONS, storeOptions);
         
     }
@@ -63,7 +66,7 @@ public class BlueprintsPersistenceBackendFactoryTest {
             try {
                 FileUtils.forceDelete(testFile);
             }catch(IOException e) {
-                
+                System.err.println(e);
             }
             testFile = null;
         }

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/resources/BlueprintsResourceSaveTest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/resources/BlueprintsResourceSaveTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Date;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -30,13 +31,15 @@ import org.junit.Test;
 import fr.inria.atlanmod.neoemf.datastore.AbstractPersistenceBackendFactory;
 import fr.inria.atlanmod.neoemf.datastore.PersistenceBackendFactoryRegistry;
 import fr.inria.atlanmod.neoemf.graph.blueprints.datastore.BlueprintsPersistenceBackendFactory;
-import fr.inria.atlanmod.neoemf.graph.blueprints.resources.BlueprintsResourceOptions;
 import fr.inria.atlanmod.neoemf.graph.blueprints.util.NeoBlueprintsURI;
 import fr.inria.atlanmod.neoemf.resources.impl.PersistentResourceFactoryImpl;
 
 public class BlueprintsResourceSaveTest {
     
-    protected String testFilePath = "src/test/resources/graphResourceSaveOptionTestFile";
+    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphResourceSaveOptionTestFile";
+
+    protected String testFilePath = TEST_FILE_PATH;
+
     protected String configFileName = "/config.properties";
     
     protected AbstractPersistenceBackendFactory persistenceBackendFactory = null;
@@ -52,7 +55,7 @@ public class BlueprintsResourceSaveTest {
         options = new HashMap();
         persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-        testFile = new File(testFilePath);
+        testFile = new File(testFilePath + String.valueOf(new Date().getTime()));
         resSet = new ResourceSetImpl();
         resSet.getResourceFactoryRegistry().getProtocolToFactoryMap().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, new PersistentResourceFactoryImpl());
         resource = resSet.createResource(NeoBlueprintsURI.createNeoGraphURI(testFile));
@@ -67,7 +70,7 @@ public class BlueprintsResourceSaveTest {
             try {
                 FileUtils.forceDelete(testFile);
             }catch(IOException e) {
-                
+                System.err.println(e);
             }
             testFile = null;
         }
@@ -87,7 +90,7 @@ public class BlueprintsResourceSaveTest {
     @Test
     public void testSaveGraphResourceNoOption() throws IOException, ConfigurationException {
         resource.save(Collections.EMPTY_MAP);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists() : "Config file does not exist";
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE);
@@ -100,7 +103,7 @@ public class BlueprintsResourceSaveTest {
     public void testSaveGraphResourceDefaultGraphTypeOption() throws IOException, ConfigurationException {
         options.put(BlueprintsResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE, BlueprintsResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE_DEFAULT);
         resource.save(options);
-        File configFile = new File(testFilePath + configFileName);
+        File configFile = new File(testFile + configFileName);
         assert configFile.exists() : "Config file does not exist";
         PropertiesConfiguration configuration = new PropertiesConfiguration(configFile);
         assert configuration.containsKey(BlueprintsResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE);

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/util/NeoBlueprintsURITest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/util/NeoBlueprintsURITest.java
@@ -11,6 +11,7 @@
 package fr.inria.atlanmod.neoemf.graph.blueprints.util;
 
 import java.io.File;
+import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
 import org.junit.After;
@@ -23,6 +24,8 @@ import fr.inria.atlanmod.neoemf.graph.blueprints.datastore.BlueprintsPersistence
 
 public class NeoBlueprintsURITest {
 
+	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoGraphURITestFile";
+
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
 	private File testFile = null;
 	
@@ -30,7 +33,7 @@ public class NeoBlueprintsURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-		testFile = new File("src/test/resource/neoGraphURITestFile");
+		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
 	}
 	
 	@After

--- a/map/src/test/java/fr/inria/atlanmod/neoemf/map/datastore/MapPersistenceBackendFactoryTest.java
+++ b/map/src/test/java/fr/inria/atlanmod/neoemf/map/datastore/MapPersistenceBackendFactoryTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -40,6 +41,8 @@ import fr.inria.atlanmod.neoemf.resources.PersistentResourceOptions;
 
 public class MapPersistenceBackendFactoryTest {
 
+    private static final String TEST_FOLDER_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "mapPersistenceBackendFactoryTest";
+
     private AbstractPersistenceBackendFactory persistenceBackendFactory = null;
     private File testFolder = null;
     private File testFile = null;
@@ -52,9 +55,9 @@ public class MapPersistenceBackendFactoryTest {
     public void setUp() throws IOException {
         persistenceBackendFactory = new MapPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, persistenceBackendFactory);
-        testFolder = new File("src/test/resources/mapPersistenceBackendFactoryTest");
+        testFolder = new File(TEST_FOLDER_PATH + String.valueOf(new Date().getTime()));
         testFolder.mkdirs();
-        testFile = new File("src/test/resources/mapPersistenceBackendFactoryTest/db");
+        testFile = new File(testFolder + "/db");
         options.put(PersistentResourceOptions.STORE_OPTIONS, storeOptions);
         
     }
@@ -66,7 +69,7 @@ public class MapPersistenceBackendFactoryTest {
             try {
                 FileUtils.forceDelete(testFolder);
             }catch(IOException e) {
-                
+                System.err.println(e);
             }
             testFolder = null;
             testFile = null;

--- a/map/src/test/java/fr/inria/atlanmod/neoemf/map/util/NeoMapURITest.java
+++ b/map/src/test/java/fr/inria/atlanmod/neoemf/map/util/NeoMapURITest.java
@@ -11,6 +11,7 @@
 package fr.inria.atlanmod.neoemf.map.util;
 
 import java.io.File;
+import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
 import org.junit.After;
@@ -23,6 +24,8 @@ import fr.inria.atlanmod.neoemf.map.datastore.MapPersistenceBackendFactory;
 
 public class NeoMapURITest {
 
+	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoMapURITestFile";
+
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = new MapPersistenceBackendFactory();
 	private File testFile = null;
 	
@@ -30,7 +33,7 @@ public class NeoMapURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, persistenceBackendFactory);
-		testFile = new File("src/test/resource/neoMapURITestFile");
+		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
 	}
 	
 	@After

--- a/tests/src/test/java/fr/inria/atlanmod/neoemf/issues/SodiIssue.java
+++ b/tests/src/test/java/fr/inria/atlanmod/neoemf/issues/SodiIssue.java
@@ -3,6 +3,7 @@ package fr.inria.atlanmod.neoemf.issues;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -26,26 +27,30 @@ import fr.inria.atlanmod.neoemf.test.commons.models.mapSample.PackContent;
 
 public class SodiIssue {
 
+    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "sodiMapResource";
+
 	protected MapSampleFactory mFac;
 	protected MapSamplePackage mPack;
 	protected Resource resource;
+
+    protected File testFile;
 	
 	@Before
 	public void setUp() {
+        testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, new MapPersistenceBackendFactory());
 		mPack = MapSamplePackage.eINSTANCE;
 		mFac = MapSampleFactory.eINSTANCE;
 		ResourceSet rSet = new ResourceSetImpl();
 		rSet.getResourceFactoryRegistry().getProtocolToFactoryMap().put(NeoMapURI.NEO_MAP_SCHEME, new PersistentResourceFactoryImpl());
-		resource = rSet.createResource(NeoMapURI.createNeoMapURI(new File("/tmp/sodiMapResource")));
+		resource = rSet.createResource(NeoMapURI.createNeoMapURI(testFile));
 	}
 	
 	@After
 	public void tearDown() throws Exception {
 		PersistentResourceImpl.shutdownWithoutUnload((PersistentResourceImpl)resource);
-		File sodiMapFile = new File("/tmp/sodiMapResource");
-		if(sodiMapFile.exists()) {
-			FileUtils.forceDelete(sodiMapFile);
+		if(testFile.exists()) {
+			FileUtils.forceDelete(testFile);
 		}
 	}
 	

--- a/tests/src/test/java/fr/inria/atlanmod/neoemf/tests/AllBackendTest.java
+++ b/tests/src/test/java/fr/inria/atlanmod/neoemf/tests/AllBackendTest.java
@@ -12,6 +12,7 @@ package fr.inria.atlanmod.neoemf.tests;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.emf.ecore.EPackage;
@@ -24,7 +25,9 @@ import fr.inria.atlanmod.neoemf.test.commons.BlueprintsResourceBuilder;
 import fr.inria.atlanmod.neoemf.test.commons.MapResourceBuilder;
 
 public class AllBackendTest {
-    
+
+    private static final String TEST_FILE_PATH_PREFIX = System.getProperty("java.io.tmpdir") + "NeoEMF/";
+
     protected PersistentResource mapResource;
     protected PersistentResource neo4jResource;
     protected PersistentResource tinkerResource;
@@ -42,9 +45,10 @@ public class AllBackendTest {
     public void setUp() throws Exception {
         assert this.ePackage != null : "EPackage not set";
         String className = this.getClass().getSimpleName();
-        mapFile     = new File("/tmp/"+className+"MapDB");
-        neo4jFile   = new File("/tmp/"+className+"Neo4j");
-        tinkerFile  = new File("/tmp/"+className+"Tinker");
+        String timestamp = String.valueOf(new Date().getTime());
+        mapFile     = new File(TEST_FILE_PATH_PREFIX + className + "MapDB" + timestamp);
+        neo4jFile   = new File(TEST_FILE_PATH_PREFIX + className + "Neo4j" + timestamp);
+        tinkerFile  = new File(TEST_FILE_PATH_PREFIX + className + "Tinker" + timestamp);
         
         mapBuilder               = new MapResourceBuilder(ePackage);
         blueprintsBuilder = new BlueprintsResourceBuilder(ePackage);
@@ -70,13 +74,25 @@ public class AllBackendTest {
         PersistentResourceImpl.shutdownWithoutUnload((PersistentResourceImpl)tinkerResource);
         
         if(mapFile.exists()) {
-            FileUtils.forceDelete(mapFile);
+            try {
+                FileUtils.forceDelete(mapFile);
+            } catch (IOException e) {
+                System.err.println(e);
+            }
         }
         if(neo4jFile.exists()) {
-            FileUtils.forceDelete(neo4jFile);
+            try {
+                FileUtils.forceDelete(neo4jFile);
+            } catch (IOException e) {
+                System.err.println(e);
+            }
         }
         if(tinkerFile.exists()) {
-            FileUtils.forceDelete(tinkerFile);
+            try {
+                FileUtils.forceDelete(tinkerFile);
+            } catch (IOException e) {
+                System.err.println(e);
+            }
         }
     }
 


### PR DESCRIPTION
Tests failed on Windows.
- Adjustment of the temporary folder to make it generic
- Adding a timestamp on directory name to prevent overwriting files

_Files don't always suppressed, probably because resources are always used (the complete unloading is done by closing the program via a hook) but I bypassed the problem.
This problem only applies to tests: files aren't deleted in a normal use_