### PR TITLE
Fix temp directory on linux.

### DIFF
--- a/core/src/test/java/fr/inria/atlanmod/neoemf/util/NeoURITest.java
+++ b/core/src/test/java/fr/inria/atlanmod/neoemf/util/NeoURITest.java
@@ -1,6 +1,8 @@
 package fr.inria.atlanmod.neoemf.util;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
@@ -14,7 +16,8 @@ import fr.inria.atlanmod.neoemf.datastore.PersistenceBackendFactoryRegistry;
 
 public class NeoURITest {
 
-	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoURITestFile";
+	private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "neoURITestFile";
 
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = Mockito.mock(AbstractPersistenceBackendFactory.class);
 	private File testFile = null;
@@ -23,7 +26,7 @@ public class NeoURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put("mock", persistenceBackendFactory);
-		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
+		testFile = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
 	}
 	
 	@After

--- a/graph/blueprints-neo4j/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/neo4j/resources/BlueprintsNeo4jResourceSaveTest.java
+++ b/graph/blueprints-neo4j/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/neo4j/resources/BlueprintsNeo4jResourceSaveTest.java
@@ -12,7 +12,6 @@ package fr.inria.atlanmod.neoemf.graph.blueprints.neo4j.resources;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -24,7 +23,7 @@ import fr.inria.atlanmod.neoemf.graph.blueprints.resources.BlueprintsResourceSav
 
 public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest {
 
-    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphNeo4jResourceSaveOptionTestFile";
+    private static final String TEST_FILENAME = "graphNeo4jResourceSaveOptionTestFile";
 
     /**
      * Used to verify a property added by Blueprints during the graph creation
@@ -38,7 +37,7 @@ public class BlueprintsNeo4jResourceSaveTest extends BlueprintsResourceSaveTest 
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
-        this.testFilePath = TEST_FILE_PATH;
+        this.testFilePath = TEST_FILENAME;
         super.setUp();
         options.put(BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_GRAPH_TYPE, BlueprintsNeo4jResourceOptions.OPTIONS_BLUEPRINTS_TYPE_NEO4J);
     }

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/datastore/BlueprintsPersistenceBackendFactoryTest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/datastore/BlueprintsPersistenceBackendFactoryTest.java
@@ -13,6 +13,8 @@ package fr.inria.atlanmod.neoemf.graph.blueprints.datastore;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,7 +43,8 @@ import fr.inria.atlanmod.neoemf.resources.PersistentResourceOptions;
 
 public class BlueprintsPersistenceBackendFactoryTest {
 
-    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphPersistenceBackendFactoryTestFile";
+    private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "graphPersistenceBackendFactoryTestFile";
     
     protected AbstractPersistenceBackendFactory persistenceBackendFactory = null;
     protected File testFile = null;
@@ -54,7 +57,7 @@ public class BlueprintsPersistenceBackendFactoryTest {
     public void setUp() {
         persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-        testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
+        testFile = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
         options.put(PersistentResourceOptions.STORE_OPTIONS, storeOptions);
         
     }
@@ -65,8 +68,8 @@ public class BlueprintsPersistenceBackendFactoryTest {
         if(testFile != null) {
             try {
                 FileUtils.forceDelete(testFile);
-            }catch(IOException e) {
-                System.err.println(e);
+            } catch(IOException e) {
+                //System.err.println(e);
             }
             testFile = null;
         }

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/resources/BlueprintsResourceSaveTest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/resources/BlueprintsResourceSaveTest.java
@@ -12,6 +12,8 @@ package fr.inria.atlanmod.neoemf.graph.blueprints.resources;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,9 +38,10 @@ import fr.inria.atlanmod.neoemf.resources.impl.PersistentResourceFactoryImpl;
 
 public class BlueprintsResourceSaveTest {
     
-    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "graphResourceSaveOptionTestFile";
+    private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "graphResourceSaveOptionTestFile";
 
-    protected String testFilePath = TEST_FILE_PATH;
+    protected String testFilePath = TEST_FILENAME;
 
     protected String configFileName = "/config.properties";
     
@@ -55,7 +58,7 @@ public class BlueprintsResourceSaveTest {
         options = new HashMap();
         persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-        testFile = new File(testFilePath + String.valueOf(new Date().getTime()));
+        testFile = TEST_DIR.resolve(testFilePath + String.valueOf(new Date().getTime())).toFile();
         resSet = new ResourceSetImpl();
         resSet.getResourceFactoryRegistry().getProtocolToFactoryMap().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, new PersistentResourceFactoryImpl());
         resource = resSet.createResource(NeoBlueprintsURI.createNeoGraphURI(testFile));
@@ -69,8 +72,8 @@ public class BlueprintsResourceSaveTest {
         if(testFile != null) {
             try {
                 FileUtils.forceDelete(testFile);
-            }catch(IOException e) {
-                System.err.println(e);
+            } catch(IOException e) {
+                //System.err.println(e);
             }
             testFile = null;
         }

--- a/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/util/NeoBlueprintsURITest.java
+++ b/graph/blueprints/src/test/java/fr/inria/atlanmod/neoemf/graph/blueprints/util/NeoBlueprintsURITest.java
@@ -11,6 +11,8 @@
 package fr.inria.atlanmod.neoemf.graph.blueprints.util;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
@@ -24,7 +26,8 @@ import fr.inria.atlanmod.neoemf.graph.blueprints.datastore.BlueprintsPersistence
 
 public class NeoBlueprintsURITest {
 
-	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoGraphURITestFile";
+	private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "neoGraphURITestFile";
 
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = new BlueprintsPersistenceBackendFactory();
 	private File testFile = null;
@@ -33,7 +36,7 @@ public class NeoBlueprintsURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoBlueprintsURI.NEO_GRAPH_SCHEME, persistenceBackendFactory);
-		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
+		testFile = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
 	}
 	
 	@After

--- a/map/src/test/java/fr/inria/atlanmod/neoemf/map/datastore/MapPersistenceBackendFactoryTest.java
+++ b/map/src/test/java/fr/inria/atlanmod/neoemf/map/datastore/MapPersistenceBackendFactoryTest.java
@@ -13,6 +13,8 @@ package fr.inria.atlanmod.neoemf.map.datastore;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,7 +43,8 @@ import fr.inria.atlanmod.neoemf.resources.PersistentResourceOptions;
 
 public class MapPersistenceBackendFactoryTest {
 
-    private static final String TEST_FOLDER_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "mapPersistenceBackendFactoryTest";
+    private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "mapPersistenceBackendFactoryTest";
 
     private AbstractPersistenceBackendFactory persistenceBackendFactory = null;
     private File testFolder = null;
@@ -55,7 +58,7 @@ public class MapPersistenceBackendFactoryTest {
     public void setUp() throws IOException {
         persistenceBackendFactory = new MapPersistenceBackendFactory();
         PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, persistenceBackendFactory);
-        testFolder = new File(TEST_FOLDER_PATH + String.valueOf(new Date().getTime()));
+        testFolder = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
         testFolder.mkdirs();
         testFile = new File(testFolder + "/db");
         options.put(PersistentResourceOptions.STORE_OPTIONS, storeOptions);
@@ -68,8 +71,8 @@ public class MapPersistenceBackendFactoryTest {
         if(testFolder != null) {
             try {
                 FileUtils.forceDelete(testFolder);
-            }catch(IOException e) {
-                System.err.println(e);
+            } catch(IOException e) {
+                //System.err.println(e);
             }
             testFolder = null;
             testFile = null;

--- a/map/src/test/java/fr/inria/atlanmod/neoemf/map/util/NeoMapURITest.java
+++ b/map/src/test/java/fr/inria/atlanmod/neoemf/map/util/NeoMapURITest.java
@@ -11,6 +11,8 @@
 package fr.inria.atlanmod.neoemf.map.util;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 
 import org.eclipse.emf.common.util.URI;
@@ -24,7 +26,8 @@ import fr.inria.atlanmod.neoemf.map.datastore.MapPersistenceBackendFactory;
 
 public class NeoMapURITest {
 
-	private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "neoMapURITestFile";
+	private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "neoMapURITestFile";
 
 	private AbstractPersistenceBackendFactory persistenceBackendFactory = new MapPersistenceBackendFactory();
 	private File testFile = null;
@@ -33,7 +36,7 @@ public class NeoMapURITest {
 	public void setUp() {
 		PersistenceBackendFactoryRegistry.getFactories().clear();
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, persistenceBackendFactory);
-		testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
+		testFile = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
 	}
 	
 	@After

--- a/tests/src/test/java/fr/inria/atlanmod/neoemf/issues/SodiIssue.java
+++ b/tests/src/test/java/fr/inria/atlanmod/neoemf/issues/SodiIssue.java
@@ -2,6 +2,8 @@ package fr.inria.atlanmod.neoemf.issues;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Date;
 
@@ -27,7 +29,8 @@ import fr.inria.atlanmod.neoemf.test.commons.models.mapSample.PackContent;
 
 public class SodiIssue {
 
-    private static final String TEST_FILE_PATH = System.getProperty("java.io.tmpdir") + "NeoEMF/" + "sodiMapResource";
+    private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
+    private static final String TEST_FILENAME = "sodiMapResource";
 
 	protected MapSampleFactory mFac;
 	protected MapSamplePackage mPack;
@@ -37,7 +40,7 @@ public class SodiIssue {
 	
 	@Before
 	public void setUp() {
-        testFile = new File(TEST_FILE_PATH + String.valueOf(new Date().getTime()));
+        testFile = TEST_DIR.resolve(TEST_FILENAME + String.valueOf(new Date().getTime())).toFile();
 		PersistenceBackendFactoryRegistry.getFactories().put(NeoMapURI.NEO_MAP_SCHEME, new MapPersistenceBackendFactory());
 		mPack = MapSamplePackage.eINSTANCE;
 		mFac = MapSampleFactory.eINSTANCE;
@@ -50,7 +53,11 @@ public class SodiIssue {
 	public void tearDown() throws Exception {
 		PersistentResourceImpl.shutdownWithoutUnload((PersistentResourceImpl)resource);
 		if(testFile.exists()) {
-			FileUtils.forceDelete(testFile);
+            try {
+                FileUtils.forceDelete(testFile);
+            } catch (IOException e) {
+                //System.err.println(e);
+            }
 		}
 	}
 	

--- a/tests/src/test/java/fr/inria/atlanmod/neoemf/tests/AllBackendTest.java
+++ b/tests/src/test/java/fr/inria/atlanmod/neoemf/tests/AllBackendTest.java
@@ -12,6 +12,8 @@ package fr.inria.atlanmod.neoemf.tests;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
@@ -26,7 +28,7 @@ import fr.inria.atlanmod.neoemf.test.commons.MapResourceBuilder;
 
 public class AllBackendTest {
 
-    private static final String TEST_FILE_PATH_PREFIX = System.getProperty("java.io.tmpdir") + "NeoEMF/";
+    private static final Path TEST_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "NeoEMF");
 
     protected PersistentResource mapResource;
     protected PersistentResource neo4jResource;
@@ -46,9 +48,9 @@ public class AllBackendTest {
         assert this.ePackage != null : "EPackage not set";
         String className = this.getClass().getSimpleName();
         String timestamp = String.valueOf(new Date().getTime());
-        mapFile     = new File(TEST_FILE_PATH_PREFIX + className + "MapDB" + timestamp);
-        neo4jFile   = new File(TEST_FILE_PATH_PREFIX + className + "Neo4j" + timestamp);
-        tinkerFile  = new File(TEST_FILE_PATH_PREFIX + className + "Tinker" + timestamp);
+        mapFile     = TEST_DIR.resolve(className + "MapDB" + timestamp).toFile();
+        neo4jFile   = TEST_DIR.resolve(className + "Neo4j" + timestamp).toFile();
+        tinkerFile  = TEST_DIR.resolve(className + "Tinker" + timestamp).toFile();
         
         mapBuilder               = new MapResourceBuilder(ePackage);
         blueprintsBuilder = new BlueprintsResourceBuilder(ePackage);
@@ -77,21 +79,21 @@ public class AllBackendTest {
             try {
                 FileUtils.forceDelete(mapFile);
             } catch (IOException e) {
-                System.err.println(e);
+                //System.err.println(e);
             }
         }
         if(neo4jFile.exists()) {
             try {
                 FileUtils.forceDelete(neo4jFile);
             } catch (IOException e) {
-                System.err.println(e);
+                //System.err.println(e);
             }
         }
         if(tinkerFile.exists()) {
             try {
                 FileUtils.forceDelete(tinkerFile);
             } catch (IOException e) {
-                System.err.println(e);
+                //System.err.println(e);
             }
         }
     }


### PR DESCRIPTION
Variables didn't end with a backslash on Linux.
Just replace the string concatenation by the `Paths.resolve()` method.