### PR TITLE
Remove useless dependencies in xcore model

### DIFF
--- a/test-commons/src/main/resources/MapSample.xcore
+++ b/test-commons/src/main/resources/MapSample.xcore
@@ -1,5 +1,5 @@
-@Ecore(nsURI="com.mapSample")
-@GenModel(modelDirectory="/test-commons/src/main/java/", modelPluginID="mapSample", rootExtendsInterface="fr.inria.atlanmod.neoemf.core.PersistentEObject", rootExtendsClass="fr.inria.atlanmod.neoemf.core.impl.PersistentEObjectImpl", reflectiveDelegation="true", importerID="org.eclipse.emf.importer.ecore", bundleManifest="false", featureDelegation="Reflective", pluginKey="")
+//@Ecore(nsURI="com.mapSample")
+//@GenModel(modelDirectory="/test-commons/src/main/java/", modelPluginID="mapSample", rootExtendsInterface="fr.inria.atlanmod.neoemf.core.PersistentEObject", rootExtendsClass="fr.inria.atlanmod.neoemf.core.impl.PersistentEObjectImpl", reflectiveDelegation="true", importerID="org.eclipse.emf.importer.ecore", bundleManifest="false", featureDelegation="Reflective", pluginKey="")
 
 package fr.inria.atlanmod.neoemf.test.commons.models.mapSample
 


### PR DESCRIPTION
Dependencies defined by `@Ecore` and `@GenModel` cause a `IOException` (which causes no problems for build and exec) when searching Eclipse configuration files that don't exist.
These dependencies aren't necessary for code generation : They are only used in model design.

**Think to comment these lines when inserting in NeoEMF**