### PR TITLE
Add dependencies in xcore model without parameters linked to a plugin

### DIFF
--- a/test-commons/src/main/resources/MapSample.xcore
+++ b/test-commons/src/main/resources/MapSample.xcore
@@ -1,5 +1,5 @@
 //@Ecore(nsURI="com.mapSample")
-//@GenModel(modelDirectory="/test-commons/src/main/java/", modelPluginID="mapSample", rootExtendsInterface="fr.inria.atlanmod.neoemf.core.PersistentEObject", rootExtendsClass="fr.inria.atlanmod.neoemf.core.impl.PersistentEObjectImpl", reflectiveDelegation="true", importerID="org.eclipse.emf.importer.ecore", bundleManifest="false", featureDelegation="Reflective", pluginKey="")
+@GenModel(modelDirectory="/test-commons/src/main/java/", rootExtendsInterface="fr.inria.atlanmod.neoemf.core.PersistentEObject", rootExtendsClass="fr.inria.atlanmod.neoemf.core.impl.PersistentEObjectImpl", reflectiveDelegation="true", importerID="org.eclipse.emf.importer.ecore", bundleManifest="false", featureDelegation="Reflective")
 
 package fr.inria.atlanmod.neoemf.test.commons.models.mapSample
 


### PR DESCRIPTION
Previously, I said that all dependencies were causing issues. But only `modelPluginID` and `pluginKey` in `GenModel` annotation cause an `IOException`.

**Only these parameters have to be removed in xcore models to ensure that no exception is thrown during build.**